### PR TITLE
Add single quotes to status filter variable

### DIFF
--- a/lib/capistrano/jira/issue_finder.rb
+++ b/lib/capistrano/jira/issue_finder.rb
@@ -17,7 +17,7 @@ module Capistrano
       def self.jql
         [
           "project = #{fetch(:jira_project_key)}",
-          "status = #{fetch(:jira_status_name)}",
+          "status = '#{fetch(:jira_status_name)}'",
           fetch(:jira_filter_jql)
         ].compact.join(' AND ')
       end


### PR DESCRIPTION
I am not sure if the JQL syntax has changed, but I have found that when using statuses that have multiple words the JQL query fails.

When trying to run the query `project = DEV AND status = In Progress` on my board, I get the following error:
```
Error in JQL Query: Expecting either a value, list or function but got 'In'. You must surround 'In' in quotation marks to use it as a value. (line 1, character 28)
```
Running `project = DEV AND status = 'In Progress'` runs successfully.